### PR TITLE
remove unecessary inport of standard.bbx

### DIFF
--- a/GEB/geb.bbx
+++ b/GEB/geb.bbx
@@ -1,7 +1,6 @@
 \ProvidesFile{geb.bbx}[biblatex style for Global Ecology and Biogeography]
 
 %% We build on the original author-year comp
-\RequireBibliographyStyle{standard}
 \RequireBibliographyStyle{authoryear-comp}
 
 %% General options to match the ELE requirements


### PR DESCRIPTION
authoryear-comp.bbx already has a \RequireBibliographyStyle{standard}